### PR TITLE
tiny change to make the E2E test with concepts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "glowing-bear-medco",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/app/services/api/medco-node/explore-search.service.ts
+++ b/src/app/services/api/medco-node/explore-search.service.ts
@@ -44,7 +44,7 @@ export class ExploreSearchService {
    */
   exploreSearch(root: string): Observable<TreeNode[]> {
     return this.apiEndpointService.postCall(
-      'node/explore/search',
+      'node/explore/search/concept',
       { type: 'children', path: root }
     ).pipe(
       map((searchResp: object) => {


### PR DESCRIPTION
Small change: "node/search" replaced to "node/search/concept", to make the actual WUI be able to load and run E2E test data