### PR TITLE
added the "operation" field to search concept and search modifier

### DIFF
--- a/src/app/models/api-request-models/medco-node/api-i2b2-item.ts
+++ b/src/app/models/api-request-models/medco-node/api-i2b2-item.ts
@@ -2,7 +2,7 @@ import { ApiI2B2Modifier } from './api-i2b2-modifier';
 
 export class ApiI2b2Item {
   queryTerm: string;
-  operator: string;
+  operator?: string;
   value?: string;
   modifier?: ApiI2B2Modifier;
   encrypted: boolean;

--- a/src/app/services/api/medco-node/explore-search.service.ts
+++ b/src/app/services/api/medco-node/explore-search.service.ts
@@ -36,17 +36,11 @@ export class ExploreSearchService {
     private apiEndpointService: ApiEndpointService,
     private injector: Injector) { }
 
-  /**
-   * Perform search concept in ontology.
-   *
-   * @param {string} root - the path to the specific tree node, must include the first slash
-   *
-   * @returns {Observable<Object>}
-   */
-  exploreSearchConcept(root: string): Observable<TreeNode[]> {
+
+  private exploreSearchConcept(operation: string, root: string): Observable<TreeNode[]> {
     return this.apiEndpointService.postCall(
       'node/explore/search/concept',
-      { path: root }
+      { operation: operation, path: root }
     ).pipe(
       map((searchResp: object) => {
         return (searchResp['results'] as object[]).map((treeNodeObj: object) => {
@@ -122,12 +116,22 @@ export class ExploreSearchService {
       })
     );
   }
+  /**
+   * Perform search concept children in ontology.
+   *
+   * @param {string} root - the path to the specific tree node, must include the first slash
+   *
+   * @returns {Observable<Object>}
+   */
+  exploreSearchConceptChildren(root: string): Observable<TreeNode[]> {
+    return this.exploreSearchConcept('children', root)
+  }
 
 
-  exploreSearchModifier(root: string, appliedPath: string, appliedConcept: string): Observable<TreeNode[]> {
+  private exploreSearchModifier(operation: string, root: string, appliedPath: string, appliedConcept: string): Observable<TreeNode[]> {
     return this.apiEndpointService.postCall(
       'node/explore/search/modifier',
-      { path: root, appliedPath: appliedPath, appliedConcept: appliedConcept }
+      { operation: operation, path: root, appliedPath: appliedPath, appliedConcept: appliedConcept }
     ).pipe(
       map((searchResp: object) => {
         return (searchResp['results'] as object[]).map((treeNodeObj: object) => {
@@ -172,5 +176,16 @@ export class ExploreSearchService {
         }
         )
       }))
+  }
+
+  /**
+   * Perform search modifier children in ontology.
+   *
+   * @param {string} root - the path to the specific tree node, must include the first slash
+   *
+   * @returns {Observable<Object>}
+   */
+  exploreSearchModifierChildren(root: string, appliedPath: string, appliedConcept: string): Observable<TreeNode[]> {
+    return this.exploreSearchModifier('children', root, appliedPath, appliedConcept)
   }
 }

--- a/src/app/services/constraint-mapping.service.ts
+++ b/src/app/services/constraint-mapping.service.ts
@@ -111,12 +111,10 @@ export class ConstraintMappingService {
         if (constraint.concept.encryptionDescriptor.encrypted) {
           // todo: children IDs implementation
           item.encrypted = true;
-          item.operator = 'exists';
           item.queryTerm = this.cryptoService.encryptIntegerWithCothorityKey(constraint.concept.encryptionDescriptor.id);
 
         } else {
           item.encrypted = false;
-          item.operator = 'exists';
           item.queryTerm = constraint.concept.path;
           if (constraint.concept.modifier !== undefined) {
             item.modifier = new ApiI2B2Modifier()
@@ -139,7 +137,6 @@ export class ConstraintMappingService {
     return constraint.variantIds.map((variantId) => {
       let item = new ApiI2b2Item();
       item.encrypted = true;
-      item.operator = 'exists';
       item.queryTerm = variantId; // todo: variant IDs are pre-encrypted
       return item;
     });

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -51,7 +51,7 @@ export class TreeNodeService {
 
       // retrieve root tree nodes and extract the concepts
       this._isLoading = true;
-      this.exploreSearchService.exploreSearchConcept('/').subscribe(
+      this.exploreSearchService.exploreSearchConceptChildren('/').subscribe(
         (treeNodes: TreeNode[]) => {
 
           // reset concepts and concept constraints
@@ -84,8 +84,8 @@ export class TreeNodeService {
 
     this._isLoading = true;
     let resultObservable: Observable<TreeNode[]> = parentNode.isModifier() ?
-      this.exploreSearchService.exploreSearchModifier(parentNode.path, parentNode.appliedPath, parentNode.appliedConcept.path) :
-      this.exploreSearchService.exploreSearchConcept(parentNode.path)
+      this.exploreSearchService.exploreSearchModifierChildren(parentNode.path, parentNode.appliedPath, parentNode.appliedConcept.path) :
+      this.exploreSearchService.exploreSearchConceptChildren(parentNode.path)
 
     resultObservable.subscribe(
       (treeNodes: TreeNode[]) => {


### PR DESCRIPTION
Recent refactorings of REST API have introduced a new field mandatory "operation" in SearchConcept and SearchModifier endpoints. This was the reason of ERROR 422 during tree-node loading.