### PR TITLE
Fix empty patient list issue

### DIFF
--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -103,6 +103,11 @@ export class QueryService {
         result.encryptedPatientList ? result.encryptedPatientList.map((encryptedPatientID) =>
           this.cryptoService.decryptIntegerWithEphemeralKey(encryptedPatientID)
         ) : []);
+
+      if (parsedResults.globalCount === 0) {
+        alert('No patients found matching this query');
+      }
+
     }
 
     console.log(`Parsed results of ${encResults.length} nodes with a global count of ${parsedResults.globalCount}`);

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -100,9 +100,9 @@ export class QueryService {
     if (this.queryType === ExploreQueryType.PATIENT_LIST) {
       parsedResults.resultInstanceID = encResults.map(({ patientSetID }) => patientSetID)
       parsedResults.patientLists = encResults.map((result) =>
-        result.encryptedPatientList.map((encryptedPatientID) =>
+        result.encryptedPatientList ? result.encryptedPatientList.map((encryptedPatientID) =>
           this.cryptoService.decryptIntegerWithEphemeralKey(encryptedPatientID)
-        ));
+        ): []);
     }
 
     console.log(`Parsed results of ${encResults.length} nodes with a global count of ${parsedResults.globalCount}`);

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -102,7 +102,7 @@ export class QueryService {
       parsedResults.patientLists = encResults.map((result) =>
         result.encryptedPatientList ? result.encryptedPatientList.map((encryptedPatientID) =>
           this.cryptoService.decryptIntegerWithEphemeralKey(encryptedPatientID)
-        ): []);
+        ) : []);
     }
 
     console.log(`Parsed results of ${encResults.length} nodes with a global count of ${parsedResults.globalCount}`);


### PR DESCRIPTION
Added an if condition around 

```
result.encryptedPatientList.map((encryptedPatientID) =>
          this.cryptoService.decryptIntegerWithEphemeralKey(encryptedPatientID)
```

to prevent null values.

An alert message pops up when there are no patients matching the query.