### PR TITLE
Hotfixes NAB

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -19,6 +19,7 @@ export class AppComponent implements OnInit {
 
   private _authenticationCompleted = false;
 
+
   constructor(private authenticationService: AuthenticationService) {
   }
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.html
@@ -1,20 +1,31 @@
 <p-accordionTab header="Subgroups" *ngIf="activated" id="gb-cohort-landing-zone-component">
 
 
-  <p-selectButton [options]="subGroups" [(ngModel)]="selectedSubGroup" (onChange)="loadSubGroup($event)">
-  </p-selectButton>
-  <br>
-  <br>
-  <p-button icon="fa fa-plus" label="Add" (onClick)='addSubGroup($event)' [disabled]="subGroups.length >= 4 ">
-  </p-button>
-  &nbsp;
-  <p-button icon="fa fa-minus" label="Remove" (onClick)='removeSubGroup($event)' [disabled]="selectedSubGroup == null ">
-  </p-button>
-  <br>
-  <br>
-  Subgroup name:
-  <br>
-  <input type="text" pInputText [(ngModel)]="name" (drop)="preventDefault($event)" placehodler="subgroup name" />
-  <br>
-  <gb-selection></gb-selection>
+  <div class="small-font">
+
+    <div>
+        <p-selectButton [options]="subGroups" [(ngModel)]="selectedSubGroup" (onChange)="loadSubGroup($event)">
+        </p-selectButton>
+      <br>
+      <br>
+      <p-button icon="fa fa-plus" label="Add" (onClick)='addSubGroup($event)' [disabled]="subGroups.length >= 4 ">
+      </p-button>
+      &nbsp;
+      <p-button icon="fa fa-minus" label="Remove" (onClick)='removeSubGroup($event)' [disabled]="selectedSubGroup == null ">
+      </p-button>
+    </div>
+
+    <div class="input-label-wrapper">
+      <div>
+        <label for="subgroupName" >
+          Subgroup name:
+        </label>
+      </div>
+      <input class="input-field input-field-margin" id="subgroupName" type="text" pInputText [(ngModel)]="name" (drop)="preventDefault($event)" placehodler="subgroup name" />
+    </div>
+
+    <div style="margin-top: 3em;">
+      <gb-selection></gb-selection>
+    </div>
+  </div>
 </p-accordionTab>

--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
@@ -1,30 +1,31 @@
 <p-accordionTab *ngIf="activated" header="Settings" id="gb-survival-settings-component">
 
   <div style="padding-top: 2em;">
-    <span class="description">
-      Time Granularity:
-    </span>
-    &nbsp;
 
-    <p-dropdown [(ngModel)]="selectedGranularity" [options]="granularities"></p-dropdown>
-    &nbsp;
-    <span style="white-space: nowrap;">
-      <span class="description">
-        Time Limit:
+    <div class="input-label-wrapper">
+      <span class="input-field-label">
+        Time Granularity: 
       </span>
-      &nbsp;
-      <input type="number" pInputText [(ngModel)]="limit" />
-      &nbsp;
-    </span>
+      <p-dropdown [(ngModel)]="selectedGranularity" [options]="granularities" class="input-field"></p-dropdown>
+    </div>
+
+    <div class ="input-label-wrapper">
+      <span style="white-space: nowrap;">
+        <span class="input-field-label">
+          Time Limit:
+        </span>
+        <input type="number" pInputText [(ngModel)]="limit" class="input-field" />
+      </span>
+    </div>
   </div>
 
-  <div style="padding-top: 2em;">
+  <!--  -->
+  <div style="padding-top: 2em;" class="input-label-wrapper">
+
     <span style="white-space: nowrap;">
-      <span class="description">
+      <label for="startEvent" class="input-field-label">
         Start Event:
-      </span>
-      &nbsp;
-      &nbsp;
+      </label>
       <div style="padding: 1em;"
         [ngStyle]="{'background-color' : startEventHovering ? 'var(--gb-clinical-green-light-light)' : 'white'}"
         (dragover)="onStartDragOver($event)" (dragleave)="onStartDragLeave($event)" (drop)="onStartDrop($event)">
@@ -38,11 +39,12 @@
         </p-autoComplete>
       </div>
     </span>
+
+
     <span style="white-space: nowrap;">
-      <span class="description">
+      <span class="input-field-label">
         End Event:&nbsp;
       </span>
-      &nbsp;
 
       <div #autoCompleteContainer style="padding: 1em;"
         [ngStyle]="{'background-color' : endEventHovering ?  'var(--gb-clinical-green-light-light)' : 'white'}"
@@ -57,8 +59,6 @@
         </p-autoComplete>
       </div>
     </span>
-
-
 
   </div>
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
@@ -1,67 +1,88 @@
 <p-accordionTab *ngIf="activated" header="Settings" id="gb-survival-settings-component">
 
-  <div style="padding-top: 2em;">
+  <div class="small-font">
 
     <div class="input-label-wrapper">
-      <span class="input-field-label">
+
+      <div>
+        <label>
         Time Granularity: 
-      </span>
-      <p-dropdown [(ngModel)]="selectedGranularity" [options]="granularities" class="input-field"></p-dropdown>
+        </label>
+      </div>
+      <div class="input-field-margin">
+        <p-dropdown dropdownIcon="pi pi-caret-down white-color" [(ngModel)]="selectedGranularity"  [options]="granularities">
+          <!--utiliser ces classes pour la fleche du dropdown ui-button-icon-left ui-clickable pi pi-caret-down-->
+        </p-dropdown>
+      </div>
     </div>
 
-    <div class ="input-label-wrapper">
-      <span style="white-space: nowrap;">
-        <span class="input-field-label">
+    <div class="input-label-wrapper">
+      <div>
+        <label for="timeLimit">
           Time Limit:
-        </span>
-        <input type="number" pInputText [(ngModel)]="limit" class="input-field" />
-      </span>
+        </label>
+      </div>
+      <input id="timeLimit" type="number" pInputText [(ngModel)]="limit" class="input-field input-field-margin" />
     </div>
-  </div>
 
-  <!--  -->
-  <div style="padding-top: 2em;" class="input-label-wrapper">
 
-    <span style="white-space: nowrap;">
-      <label for="startEvent" class="input-field-label">
-        Start Event:
-      </label>
-      <div style="padding: 1em;"
+    <!-- <div *ngIf="(operatorState !== null) && !isBetween() " class="d-inline-block">
+      <input type="number" [step]="integerOrFloat" [min]="positive" class="col-sm-8" -->
+
+    <!--  -->
+    <div class="input-label-wrapper">
+      <div>
+        <label>
+          Start Event:
+        </label>
+      </div>
+      <div
+        class="input-field-margin"
         [ngStyle]="{'background-color' : startEventHovering ? 'var(--gb-clinical-green-light-light)' : 'white'}"
         (dragover)="onStartDragOver($event)" (dragleave)="onStartDragLeave($event)" (drop)="onStartDrop($event)">
-        <p-autoComplete #autoComplete [(ngModel)]="startConcept" [suggestions]="suggestedStartConcepts"
+        <p-autoComplete 
+          #autoComplete [(ngModel)]="startConcept" [suggestions]="suggestedStartConcepts"
           (completeMethod)="searchStart($event)" field="path" (onDropDownClick)="onDropdown($event)"
-          placeholder="Select clear concept" dropdown="true">
+          placeholder="Select clear concept" dropdown="true"
+          
+          [inputStyle]="{'width':'auto'}"
+          styleClass="gb-concept-constraint-input"
+          size="60">
 
           <ng-template let-concept pTemplate="item">
             <span>{{concept.label}}</span>
           </ng-template>
         </p-autoComplete>
       </div>
-    </span>
+    </div>
 
+    <div class="input-label-wrapper">
+      <div>
+        <label>
+          End Event:&nbsp;
+        </label>
+      </div>
 
-    <span style="white-space: nowrap;">
-      <span class="input-field-label">
-        End Event:&nbsp;
-      </span>
-
-      <div #autoCompleteContainer style="padding: 1em;"
+      <div #autoCompleteContainer
+        class="input-field-margin"
         [ngStyle]="{'background-color' : endEventHovering ?  'var(--gb-clinical-green-light-light)' : 'white'}"
         (dragover)="onEndDragOver($event)" (dragleave)="onEndDragLeave($event)" (drop)="onEndDrop($event)">
         <p-autoComplete #autoComplete [(ngModel)]="endConcept" [suggestions]="suggestedEndConcepts"
           (completeMethod)="searchEnd($event)" field="path" (onDropDownClick)="onDropdown($event)"
-          placeholder="Select clear concept" dropdown="true">
+          placeholder="Select clear concept" dropdown="true"
+          
+          [inputStyle]="{'width':'auto'}"
+          styleClass="gb-concept-constraint-input"
+          size="60">
 
           <ng-template let-concept pTemplate="item">
             <span>{{concept.label}}</span>
           </ng-template>
         </p-autoComplete>
       </div>
-    </span>
+    </div>
+
 
   </div>
-
-
 
 </p-accordionTab>

--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
@@ -10,9 +10,7 @@
         </label>
       </div>
       <div class="input-field-margin">
-        <p-dropdown dropdownIcon="pi pi-caret-down white-color" [(ngModel)]="selectedGranularity"  [options]="granularities">
-          <!--utiliser ces classes pour la fleche du dropdown ui-button-icon-left ui-clickable pi pi-caret-down-->
-        </p-dropdown>
+        <p-dropdown dropdownIcon="pi pi-caret-down white-color" [(ngModel)]="selectedGranularity"  [options]="granularities"></p-dropdown>
       </div>
     </div>
 
@@ -26,10 +24,6 @@
     </div>
 
 
-    <!-- <div *ngIf="(operatorState !== null) && !isBetween() " class="d-inline-block">
-      <input type="number" [step]="integerOrFloat" [min]="positive" class="col-sm-8" -->
-
-    <!--  -->
     <div class="input-label-wrapper">
       <div>
         <label>

--- a/src/app/modules/gb-explore-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.html
+++ b/src/app/modules/gb-explore-module/constraint-components/gb-combination-constraint/gb-combination-constraint.component.html
@@ -15,7 +15,7 @@
                      (constraintRemoved)="onConstraintRemoved(child)"></gb-constraint>
     </div>
 
-    <div class="form-inline gb-combination-constraint-input-container">
+    <div class="form-inline input-field-margin">
 
       <button *ngIf="allowGroupChildren()"
               type="button"

--- a/src/app/modules/gb-explore-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.html
+++ b/src/app/modules/gb-explore-module/constraint-components/gb-concept-constraint/gb-concept-constraint.component.html
@@ -1,5 +1,10 @@
 <div (drop)="onDrop($event)">
   <div class="gb-constraint-child-container">
+    <div>
+      <label *ngIf="(depth === 1) && queryTimingSameInstance" style="margin: 6px;">Same instance:</label>                
+      <p-checkbox *ngIf="(depth === 1) && queryTimingSameInstance" [(ngModel)]="panelTimingSameInstance" [binary]="true"></p-checkbox>
+    </div>
+
     <label>Ontology concept: </label>
     <p-autoComplete #autoComplete
                     [(ngModel)]="selectedConcept"
@@ -13,8 +18,7 @@
                     dropdown="true"
                     (onDropdownClick)="onDropdown($event)"></p-autoComplete>
 
-    <label *ngIf="(depth === 1) && queryTimingSameInstance">Same instance:</label>                
-    <p-checkbox *ngIf="(depth === 1) && queryTimingSameInstance" [(ngModel)]="panelTimingSameInstance" [binary]="true"></p-checkbox>
+
                     
   
 

--- a/src/app/modules/gb-explore-module/gb-explore.component.css
+++ b/src/app/modules/gb-explore-module/gb-explore.component.css
@@ -22,6 +22,7 @@
   border-radius: 6px;
   padding-left: 2em;
   overflow: hidden;
+  padding-top: .5em;
 }
 
 .gb-data-selection-accordion-sub-header-2 #save-box{

--- a/src/app/modules/gb-explore-module/gb-explore.component.html
+++ b/src/app/modules/gb-explore-module/gb-explore.component.html
@@ -10,7 +10,7 @@
       <span id="save-box">
         <input [(ngModel)]="cohortName" pInputText (keydown)="saveIfEnter($event)" placeholder="Cohort name" (drop)="preventDefault($event)"/>
         <span>&nbsp;</span>
-        <button
+        <button 
           class="btn btn-outline-primary btn-sm gb-data-selection-overview-panel-btn {{lastSuccessfulSet ?  '' : 'gb-explore-waiting-cohort'}}"
           type="button" [disabled]="!lastSuccessfulSet" (click)="save()">
 
@@ -47,6 +47,9 @@
 
     </div>
   </div>
-  <gb-selection></gb-selection>
+
+  <div style="margin-top: 1em;">
+    <gb-selection></gb-selection>
+  </div>
 
 </div>

--- a/src/app/modules/gb-explore-module/gb-selection-component/gb-selection.component.html
+++ b/src/app/modules/gb-explore-module/gb-selection-component/gb-selection.component.html
@@ -1,12 +1,18 @@
-<div>
+<div class="small-font">
+  <!-- https://stackoverflow.com/questions/tagged/ui-grid?tab=Votes -->
+<!-- how to use the grid for sizing components https://stackoverflow.com/questions/41354416/primeng-p-dropdown-stretch-100 -->
 
-  <br>
-  <p-dropdown [(ngModel)]="queryTiming" [options]="timings" [ngStyle]="{'font-size':'small','margin-bottom':'1em'}"></p-dropdown>
-  <div>&nbsp;</div>
-  <!-- Inclusion criteria -->
+  <div class="input-label-wrapper">
+    <div class="input-field-margin">
+        <p-dropdown 
+        [style]="{'min-width':'25em'}"
+        dropdownIcon="pi pi-caret-down white-color" 
+        [(ngModel)]="queryTiming" [options]="timings" [ngStyle]="{'margin-bottom':'1em'}"></p-dropdown>
+    </div>
+  </div>
   
   <div #inclusionCriteriaBox
-       class="criteria-box">
+       class="criteria-box input-label-wrapper">
     <p><b>Inclusion</b> criteria:</p>
     <gb-constraint #rootInclusionConstraintComponent
                 [constraint]="constraintService.rootInclusionConstraint"
@@ -15,7 +21,7 @@
 
   <!-- Exclusion criteria -->
   <div #exclusionCriteriaBox
-       class="criteria-box">
+       class="criteria-box input-label-wrapper">
     <p><b>Exclusion</b> criteria:</p>
     <gb-constraint #rootExclusionConstraintComponent
                 [constraint]="constraintService.rootExclusionConstraint"

--- a/src/app/modules/gb-main-module/gb-main.routing.ts
+++ b/src/app/modules/gb-main-module/gb-main.routing.ts
@@ -21,10 +21,6 @@ export const routes: Routes = [
     loadChildren: '../gb-explore-module/gb-explore.module#GbExploreModule'
   },
   {
-    path: 'explore/results',
-    loadChildren: '../gb-explore-results-module/gb-explore-results.module#GbExploreResultsModule'
-  },
-  {
     path: 'analysis',
     loadChildren: '../gb-analysis-module/gb-analysis.module#GbAnalysisModule'
   },

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.html
@@ -1,4 +1,4 @@
-<div id="cohorts-component">
+<div id="cohorts-component" class="small-font">
   <p-confirmDialog header="Confirmation" icon="pi pi-exclamation-triangle"></p-confirmDialog>
   <button pButton class="ui-button-secondary" [disabled]="cohortService.isRefreshing"
     [ngStyle]="{'color': cohortService.isRefreshing ? 'var(--gb-light-light-clinical-green)':'var(--gb-clinical-green)'}"

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
@@ -14,7 +14,7 @@
     </div>
 
     <div>
-      <p-accordionTab header=Cohort [selected]="true">
+      <p-accordionTab header="Saved Cohorts" [selected]="true">
         <gb-cohorts></gb-cohorts>
       </p-accordionTab>
     </div>

--- a/src/app/services/navbar.service.ts
+++ b/src/app/services/navbar.service.ts
@@ -37,9 +37,9 @@ export class NavbarService {
 
       // 0: explore tab, default page
       { label: OperationType.EXPLORE, routerLink: '/explore' },
- 
+
       // 1: survival analysis tab
-      { label: OperationType.ANALYSIS, routerLink: '/analysis' } 
+      { label: OperationType.ANALYSIS, routerLink: '/analysis' }
     ];
   }
 

--- a/src/app/services/navbar.service.ts
+++ b/src/app/services/navbar.service.ts
@@ -25,7 +25,7 @@ export class NavbarService {
   private _isAnalysis = false;
   private _isSurvivalRes = new Array<boolean>();
 
-  private EXPLORE_INDEX = 0; 
+  private EXPLORE_INDEX = 0;
   private ANALYSIS_INDEX = 1;
 
 
@@ -40,7 +40,6 @@ export class NavbarService {
       // 1: survival analysis tab
       { label: 'Analysis', routerLink: '/analysis' }
     ];
- 
   }
 
   updateNavbar(routerLink: string) {

--- a/src/app/services/navbar.service.ts
+++ b/src/app/services/navbar.service.ts
@@ -25,6 +25,9 @@ export class NavbarService {
   private _isAnalysis = false;
   private _isSurvivalRes = new Array<boolean>();
 
+  private EXPLORE_INDEX = 0; 
+  private ANALYSIS_INDEX = 1;
+
 
 
   constructor(private queryService: QueryService) {
@@ -34,22 +37,14 @@ export class NavbarService {
       // 0: explore tab, default page
       { label: 'Explore', routerLink: '/explore' },
 
-      // 1: explore results tab, not visible by default
-      { label: 'Explore Results', routerLink: '/explore/results', visible: false },
-
-      // 2: survival analysis tab
+      // 1: survival analysis tab
       { label: 'Analysis', routerLink: '/analysis' }
     ];
-
-    // hook to update explore results tab visibility
-    this.queryService.displayExploreResultsComponent.subscribe((display) => {
-      this.items[1].visible = display;
-    })
+ 
   }
 
   updateNavbar(routerLink: string) {
     this.isExplore = (routerLink === '/explore' || routerLink === '');
-    this.isExploreResults = (routerLink === '/explore/results');
     this.isAnalysis = (routerLink === '/analysis')
     for (let i = 0; i < this.isSurvivalRes.length; i++) {
       this.isSurvivalRes[i] = (routerLink === `/survival/${i}`)
@@ -57,15 +52,13 @@ export class NavbarService {
     console.log('Updated router link: ', routerLink)
 
     if (this.isExplore) {
-      this.activeItem = this._items[0];
-    } else if (this.isExploreResults) {
-      this.activeItem = this._items[1];
+      this.activeItem = this._items[this.EXPLORE_INDEX];
     } else if (this.isAnalysis) {
-      this.activeItem = this._items[2];
+      this.activeItem = this._items[this.ANALYSIS_INDEX];
     } else {
       for (let i = 0; i < this.isSurvivalRes.length; i++) {
         if (this.isSurvivalRes[i]) {
-          this.activeItem = this._items[i + 3]
+          this.activeItem = this._items[i + this.items.length]
           this._selectedSurvivalId.next(i)
           break
         }

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -191,6 +191,7 @@ export class TreeNodeService {
         constraintFromModifier.concept = sourceConcept;
         constraintService.conceptConstraints.push(constraintFromModifier);
         constraintService.allConstraints.push(constraintFromModifier);
+        node.leaf = true;
         node.icon = 'fa fa-file-o';
         break;
       case TreeNodeType.MODIFIER_FOLDER:

--- a/src/styles/bootstrap.css
+++ b/src/styles/bootstrap.css
@@ -471,7 +471,7 @@ th {
 
 label {
   display: inline-block;
-  margin-bottom: .5rem;
+  margin-bottom: 1rem;
 }
 
 button:focus {

--- a/src/styles/primeng-theme.css
+++ b/src/styles/primeng-theme.css
@@ -282,7 +282,7 @@ body .ui-dropdown .ui-dropdown-label {
   background: #ffffff;
 }
 body .ui-dropdown .ui-dropdown-trigger {
-  background-color: #ffffff;
+  background-color: var(--gb-clinical-green);
 }
 body .ui-dropdown .ui-dropdown-trigger .fa {
   color: #55595c;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -529,16 +529,29 @@ gb-cross-table .ui-resizable-column {
   min-width: 30px;
   width: 100px;
 }
-
+ 
 .input-label-wrapper {
-  display: inline-block;
-	margin: 0.5em;
+  margin-top: 1em;
 }
 
-.input-label-wrapper .input-field-label {
-    display: block;
+.input-field-margin {
+  margin-left: 1.6em;
 }
 
-.input-label-wrapper .input-field {
-  margin-left: 1em;
+.input-field {
+  border: 1px solid #d6d6d6;
+}
+
+input.input-field {
+  padding: 0.5em 0.75em;
+  border-radius: 0.25em;
+  color: #55595c;
+}
+
+.white-color {
+  color: white;
+}
+ 
+.small-font {
+  font-size: small;
 }

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -529,3 +529,16 @@ gb-cross-table .ui-resizable-column {
   min-width: 30px;
   width: 100px;
 }
+
+.input-label-wrapper {
+  display: inline-block;
+	margin: 0.5em;
+}
+
+.input-label-wrapper .input-field-label {
+    display: block;
+}
+
+.input-label-wrapper .input-field {
+  margin-left: 1em;
+}


### PR DESCRIPTION
Fix the following problems:

- Remove the display of the "explore results" tab.

- Harmonize the interface fonts and overall look of the forms within the Survival analysis and Explore tabs.
Set the font to be the same in the "settings" and "subgroups" parts of the survival analysis interface.
Align the elements of the different forms.
Increase length of the start event and end event inputs of the survival analysis settings form.
Make the font sizes the same in the survival analysis and explore accordions contents as well as in the Saved cohorts accordions. The new font size is the same as the font of the tree nodes of the ontology.


![PR1](https://user-images.githubusercontent.com/8803839/106631281-e3f89000-657c-11eb-9a86-1bc2ea33b152.png)

 - Move the "same instance" checkbox above the ontology concept name in the dropzone of concepts

 - Change the name of the Cohort accordion to Saved Cohort.

- Remove the display of the little caret for leaf elements of the ontology (leaf elements were not set as leafs in the logic of the code).


