### PR TITLE
Internal states explore analyses

### DIFF
--- a/src/app/modules/gb-analysis-module/gb-analysis.module.ts
+++ b/src/app/modules/gb-analysis-module/gb-analysis.module.ts
@@ -30,6 +30,7 @@ import { DropdownModule } from 'primeng/dropdown';
 import { AutoCompleteModule } from 'primeng/autocomplete'
 import { GbSelectionModule } from '../gb-explore-module/gb-selection-component/gb-selection.module';
 import { SurvivalService } from 'app/services/survival-analysis.service';
+import { AnalysisService } from 'app/services/analysis.service';
 
 
 @NgModule({
@@ -58,7 +59,7 @@ import { SurvivalService } from 'app/services/survival-analysis.service';
     GbSelectionModule
   ],
 
-  providers: [ApiSurvivalAnalysisService, SurvivalService],
+  providers: [ApiSurvivalAnalysisService, AnalysisService, SurvivalService],
 
   exports: [
     RouterModule

--- a/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.html
@@ -1,4 +1,4 @@
-<p-accordionTab header="Subgroups" *ngIf="activated" id="gb-cohort-landing-zone-component">
+<p-accordionTab header="Subgroups" *ngIf="activated" id="gb-cohort-landing-zone-component" [(selected)]="expanded">
 
 
   <div class="small-font">

--- a/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.ts
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.ts
@@ -12,6 +12,7 @@ import { MessageHelper } from 'app/utilities/message-helper';
 import { SurvivalService } from 'app/services/survival-analysis.service';
 import { SubGroup } from 'app/services/survival-analysis.service';
 import { OperationType } from 'app/models/operation-models/operation-types';
+import { AnalysisService } from 'app/services/analysis.service';
 
 
 
@@ -33,7 +34,9 @@ export class GbCohortLandingZoneComponent implements OnInit {
 
   OperationType = OperationType
 
-  constructor(private constraintService: ConstraintService, private survivalService: SurvivalService) {
+  constructor(private analysisService: AnalysisService,
+    private constraintService: ConstraintService,
+    private survivalService: SurvivalService) {
     this._subGroups = new Array()
     this._usedNames = new Set()
 
@@ -54,6 +57,15 @@ export class GbCohortLandingZoneComponent implements OnInit {
   get activated(): boolean {
     return this._activated
   }
+
+  get expanded(): boolean {
+    return this.analysisService.survivalSubGroupExpanded
+  }
+
+  set expanded(val: boolean) {
+    this.analysisService.survivalSubGroupExpanded = val
+  }
+
 
   get subGroups(): SelectItem[] {
     return this._subGroups

--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
@@ -1,4 +1,4 @@
-<p-accordionTab *ngIf="activated" header="Settings" id="gb-survival-settings-component">
+<p-accordionTab *ngIf="activated" header="Settings" id="gb-survival-settings-component" [(selected)]="expanded">
 
   <div class="small-font">
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.ts
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.ts
@@ -18,6 +18,7 @@ import { SelectItem } from 'primeng/api';
 import { SurvivalService } from 'app/services/survival-analysis.service';
 import { TreeNodeType } from 'app/models/tree-models/tree-node-type';
 import { When } from 'app/models/survival-analysis/when-type';
+import { AnalysisService } from 'app/services/analysis.service';
 
 @Component({
   selector: 'gb-survival-settings',
@@ -51,7 +52,8 @@ export class GbSurvivalSettingsComponent implements OnInit, OnChanges {
 
   @Output() changedEventConcepts: EventEmitter<boolean> = new EventEmitter()
 
-  constructor(private constraintService: ConstraintService,
+  constructor(private analysisService: AnalysisService,
+    private constraintService: ConstraintService,
     private survivalService: SurvivalService,
     private element: ElementRef,
     private treeNodeService: TreeNodeService) { }
@@ -150,6 +152,14 @@ export class GbSurvivalSettingsComponent implements OnInit, OnChanges {
   @Input()
   set activated(bool: boolean) {
     this._activated = bool
+  }
+
+  get expanded(): boolean {
+    return this.analysisService.survivalSettingsExpanded
+  }
+
+  set expanded(val: boolean) {
+    this.analysisService.survivalSettingsExpanded = val
   }
 
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
@@ -1,4 +1,4 @@
-<p-accordionTab header="Analyses" id="gb-top-component" [selected]="true">
+<p-accordionTab header="Analyses" id="gb-top-component" [(selected)]="expanded">
 
 
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.ts
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.ts
@@ -17,6 +17,7 @@ import { MessageHelper } from 'app/utilities/message-helper';
 import { SurvivalResultsService } from 'app/services/survival-results.service';
 import { CohortService } from 'app/services/cohort.service';
 import { SurvivalService } from 'app/services/survival-analysis.service';
+import { AnalysisService } from 'app/services/analysis.service';
 
 @Component({
   selector: 'gb-top',
@@ -31,32 +32,40 @@ export class GbTopComponent implements OnInit {
   // _selectedLinearRegression:boolean
   // _selectedLogisticRegression:boolean
 
-  _selected: AnalysisType
   _clearRes: Subject<SurvivalAnalysisClear>
   _available = AnalysisType.ALL_TYPES
   _survivalAnalysisResponses: ApiSurvivalAnalysisResponse[]
   _ready = false
 
-  constructor(private survivalAnalysisService: SurvivalService,
+  constructor(private analysisService: AnalysisService,
+    private survivalAnalysisService: SurvivalService,
     private survivalResultsService: SurvivalResultsService,
     private cohortService: CohortService) {
     this._clearRes = new Subject<SurvivalAnalysisClear>()
+  }
+
+  get expanded(): boolean {
+    return this.analysisService.analysisTypeExpanded
+  }
+
+  set expanded(val: boolean) {
+    this.analysisService.analysisTypeExpanded = val
   }
 
   set selected(sel: AnalysisType) {
     if (sel === AnalysisType.SURVIVAL) {
       this._selectedSurvival = true
     }
-    this._selected = sel
+    this.analysisService.selected = AnalysisType.SURVIVAL
   }
 
   get selected(): AnalysisType {
-    return this._selected
+    return this.analysisService.selected
   }
 
 
   get selectedSurvival(): boolean {
-    return this._selectedSurvival
+    return this.analysisService.selected === AnalysisType.SURVIVAL
   }
 
   get available(): AnalysisType[] {

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -28,8 +28,6 @@ import { OperationType } from 'app/models/operation-models/operation-types';
   styleUrls: ['./gb-explore.component.css']
 })
 export class GbExploreComponent implements AfterViewChecked {
-  _cohortName: string
-  _lastSuccessfulSet: number[]
 
   OperationType = OperationType
 
@@ -39,7 +37,7 @@ export class GbExploreComponent implements AfterViewChecked {
     private medcoNetworkService: MedcoNetworkService,
     private changeDetectorRef: ChangeDetectorRef) {
     this.queryService.lastSuccessfulSet.subscribe(resIDs => {
-      this._lastSuccessfulSet = resIDs
+      this.lastSuccessfulSet = resIDs
     })
   }
 
@@ -107,8 +105,11 @@ export class GbExploreComponent implements AfterViewChecked {
     return this.queryService.queryType;
   }
 
+  set lastSuccessfulSet(setIDs: number[]) {
+    this.cohortService.lastSuccessfulSet = setIDs
+  }
   get lastSuccessfulSet(): number[] {
-    return this._lastSuccessfulSet
+    return this.cohortService.lastSuccessfulSet
   }
   get globalCount(): Observable<string> {
     return this.queryService.queryResults.pipe(map((queryResults) =>
@@ -116,10 +117,10 @@ export class GbExploreComponent implements AfterViewChecked {
     ));
   }
   set cohortName(name: string) {
-    this._cohortName = name
+    this.cohortService.cohortName = name
   }
   get cohortName(): string {
-    return this._cohortName
+    return this.cohortService.cohortName
   }
 
   get isUpdating(): boolean {

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-tree-nodes/gb-tree-nodes.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-tree-nodes/gb-tree-nodes.component.ts
@@ -58,9 +58,9 @@ export class GbTreeNodesComponent implements AfterViewInit, AfterViewChecked {
   hits = 0;
 
   constructor(public treeNodeService: TreeNodeService,
-              private constraintService: ConstraintService,
-              private queryService: QueryService,
-              private element: ElementRef) {
+    private constraintService: ConstraintService,
+    private queryService: QueryService,
+    private element: ElementRef) {
     this.expansionStatus = {
       expanded: false,
       treeNodeElm: null,
@@ -186,6 +186,9 @@ export class GbTreeNodesComponent implements AfterViewInit, AfterViewChecked {
       this.expansionStatus['treeNodeElm'] = event.originalEvent.target.parentElement.parentElement;
       this.expansionStatus['treeNode'] = event.node;
       this.treeNodeService.loadChildrenNodes(event.node, this.constraintService);
+      if (event.node.leaf) {
+        this.expansionStatus['expanded'] = false;
+      }
     }
   }
 

--- a/src/app/services/analysis.service.ts
+++ b/src/app/services/analysis.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { AnalysisType } from 'app/models/analysis-models/analysis-type';
 
 @Injectable({
   providedIn: 'root'
@@ -8,7 +9,17 @@ export class AnalysisService {
 
   _selected: AnalysisType
 
+  _analysisTypeExpanded = true
+
+  _survivalSettingsExpanded = false
+
+  _survivalSubGroupExpanded = false
+
   constructor() { }
+
+  get available(): AnalysisType[] {
+    return this._available
+  }
 
   get selected(): AnalysisType {
     return this._selected
@@ -19,8 +30,28 @@ export class AnalysisService {
     this._selected = analysisType
   }
 
-  get available(): AnalysisType[] {
-    return this._available
+  get analysisTypeExpanded(): boolean {
+    return this._analysisTypeExpanded
+  }
+
+  set analysisTypeExpanded(val: boolean) {
+    this._analysisTypeExpanded = val
+  }
+
+  get survivalSettingsExpanded(): boolean {
+    return this._survivalSettingsExpanded
+  }
+
+  set survivalSettingsExpanded(val: boolean) {
+    this._survivalSettingsExpanded = val
+  }
+
+  get survivalSubGroupExpanded(): boolean {
+    return this._survivalSubGroupExpanded
+  }
+
+  set survivalSubGroupExpanded(val: boolean) {
+    this._survivalSubGroupExpanded = val
   }
 
   selectSurvival() {
@@ -33,27 +64,5 @@ export class AnalysisService {
 
   selectLogisticRegression() {
     this._selected = AnalysisType.LOGISTIC_REGRESSION
-  }
-}
-
-export class AnalysisType {
-
-  get name(): string {
-    return this._name
-  }
-  static readonly SURVIVAL = new AnalysisType('Survival')
-  static readonly LINEAR_REGRESSION = new AnalysisType('Linear Regresion')
-  static readonly LOGISTIC_REGRESSION = new AnalysisType('Logistic Regression')
-
-  static readonly ALL_TYPES = [
-    AnalysisType.SURVIVAL,
-    AnalysisType.LINEAR_REGRESSION,
-    AnalysisType.LOGISTIC_REGRESSION
-  ]
-  _name: string
-
-  private constructor(name: string) {
-    this._name = name
-
   }
 }

--- a/src/app/services/cohort.service.ts
+++ b/src/app/services/cohort.service.ts
@@ -33,6 +33,10 @@ export class CohortService {
 
   private _isRefreshing: boolean
 
+  // internal states of the explore component handling cohorts
+  _cohortName: string
+  _lastSuccessfulSet: number[]
+
   // term restoration
   public restoring: Subject<boolean>
   private _queryTiming: Subject<ApiI2b2Timing>
@@ -176,6 +180,22 @@ export class CohortService {
   }
   get isRefreshing(): boolean {
     return this._isRefreshing
+  }
+
+  set lastSuccessfulSet(setIDs: number[]) {
+    this._lastSuccessfulSet = setIDs
+  }
+
+  get lastSuccessfulSet(): number[] {
+    return this._lastSuccessfulSet
+  }
+
+  set cohortName(name: string) {
+    this._cohortName = name
+  }
+
+  get cohortName(): string {
+    return this._cohortName
   }
 
   get queryTiming(): Observable<ApiI2b2Timing> {

--- a/src/app/services/tree-node.service.ts
+++ b/src/app/services/tree-node.service.ts
@@ -13,7 +13,6 @@ import {Concept} from '../models/constraint-models/concept';
 import {ConceptConstraint} from '../models/constraint-models/concept-constraint';
 import {TreeNode} from '../models/tree-models/tree-node';
 import {ConstraintService} from './constraint.service';
-import {ValueType} from '../models/constraint-models/value-type';
 import {ErrorHelper} from '../utilities/error-helper';
 import {TreeNodeType} from '../models/tree-models/tree-node-type';
 import {AppConfig} from '../config/app.config';
@@ -95,6 +94,9 @@ export class TreeNodeService {
         parentNode.attachModifierData(treeNodes);
         this.processTreeNodes(parentNode.children, constraintService);
         this._isLoading = false;
+        if (treeNodes.length === 0) {
+          parentNode.leaf = true
+        }
       },
       (err) => {
         ErrorHelper.handleError('Error during tree children loading', err);
@@ -159,23 +161,6 @@ export class TreeNodeService {
           constraintService.conceptConstraints.push(constraint);
           constraintService.allConstraints.push(constraint);
         }
-        switch (node.valueType) {
-          case ValueType.NUMERICAL:
-            node.icon = 'icon-123';
-            break;
-          case ValueType.CATEGORICAL:
-            node.icon = 'icon-abc';
-            break;
-          case ValueType.DATE:
-            node.icon = 'fa fa-calendar';
-            break;
-          case ValueType.TEXT:
-            node.icon = 'fa fa-newspaper-o';
-            break;
-          case ValueType.SIMPLE:
-          default:
-            node.icon = 'fa fa-file';
-        }
         break;
       case TreeNodeType.GENOMIC_ANNOTATION:
         if (constraintService.genomicAnnotations.filter(
@@ -191,13 +176,10 @@ export class TreeNodeService {
         constraintFromModifier.concept = sourceConcept;
         constraintService.conceptConstraints.push(constraintFromModifier);
         constraintService.allConstraints.push(constraintFromModifier);
-        node.leaf = true;
-        node.icon = 'fa fa-file-o';
-        break;
-      case TreeNodeType.MODIFIER_FOLDER:
-        node.icon = '';
-        node.expandedIcon = 'fa fa-folder-open-o';
-        node.collapsedIcon = 'fa fa-folder-o';
+        if (node.nodeType === TreeNodeType.MODIFIER) {
+          node.leaf = true;
+          node.icon = 'fa fa-file';
+        }
         break;
       default:
         break;


### PR DESCRIPTION
Internal states handling improved for Explore and Analyses tabs.

A warning was popping when the get cohort returned cohorts with same update date

A new bug made the modifier folder having no descendant

Aspect of leaves and folder in tree nodes were regressed