### PR TITLE
Fix height of header.

### DIFF
--- a/src/app/modules/gb-explore-module/gb-explore.component.css
+++ b/src/app/modules/gb-explore-module/gb-explore.component.css
@@ -23,7 +23,7 @@
   padding-left: 2em;
   padding-right: 2em;
   overflow: hidden;
-  height: 2em;
+  min-height: 2em;
   display: flex;
   align-items: center;
   justify-content: space-between;


### PR DESCRIPTION
The interface looked like that when the window of the browser was small
![heightBug](https://user-images.githubusercontent.com/8803839/107782122-f7f47c80-6d48-11eb-87ba-3b316c6f0d8d.png)

I fixed it by changing the _height_ of the gb-data-selection-accordion-sub-header-2 component to a _min-height_ css property
![heightBugFix](https://user-images.githubusercontent.com/8803839/107782300-2eca9280-6d49-11eb-9ca2-ecf351e1f48f.png)

It doesnt change the appearance when the window size is of normal size but fixes the problem of window size when the window is small.