### PR TITLE
Fixes survival limit units+clear criteria+saved cohort bugs

### DIFF
--- a/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-survival-settings/gb-survival-settings.component.html
@@ -3,25 +3,15 @@
   <div class="small-font">
 
     <div class="input-label-wrapper">
-
-      <div>
-        <label>
-          Time Granularity:
-        </label>
-      </div>
-      <div class="input-field-margin">
-        <p-dropdown dropdownIcon="pi pi-caret-down white-color" [(ngModel)]="selectedGranularity"
-          [options]="granularities"></p-dropdown>
-      </div>
-    </div>
-
-    <div class="input-label-wrapper">
       <div>
         <label for="timeLimit">
           Time Limit:
         </label>
       </div>
       <input id="timeLimit" type="number" pInputText [(ngModel)]="limit" class="input-field input-field-margin" />
+      <span>&nbsp;&nbsp;</span>
+      <p-dropdown dropdownIcon="pi pi-caret-down white-color" [(ngModel)]="selectedGranularity"
+          [options]="granularities"></p-dropdown>
     </div>
 
 

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.ts
@@ -172,6 +172,7 @@ export class GbCohortsComponent implements AfterViewInit, OnInit {
       header: 'Confirmation',
       icon: null,
       accept: () => {
+        this.savedCohortsPatientListService.removePatientList(cohort.name)
         this.cohortService.removeCohorts(cohort)
         if (this.cohortService.selectedCohort && this.cohortService.selectedCohort === cohort) {
           this.cohortService.selectedCohort = null

--- a/src/app/services/cohort.service.ts
+++ b/src/app/services/cohort.service.ts
@@ -171,7 +171,9 @@ export class CohortService {
       this._selectedCohort.selected = false
     }
     this._selectedCohort = cohort
-    this._selectedCohort.selected = true
+    if (cohort) {
+      this._selectedCohort.selected = true
+    }
     this._selectingCohort.next(cohort)
   }
 

--- a/src/app/services/constraint.service.ts
+++ b/src/app/services/constraint.service.ts
@@ -238,12 +238,12 @@ export class ConstraintService {
         this._operationType = opType
         break;
       case OperationType.ANALYSIS:
-        console.log('The operation type of constraint service is now Analysis.')
 
         // save current selection
         if (this._operationType === OperationType.EXPLORE) {
           this._exploreRootInclusionConstraint = this.rootInclusionConstraint.clone()
           this._exploreRootExclusionConstraint = this.rootExclusionConstraint.clone()
+          this.clearConstraint()
         }
         this._operationType = opType
         break;

--- a/src/app/services/saved-cohorts-patient-list.service.ts
+++ b/src/app/services/saved-cohorts-patient-list.service.ts
@@ -189,6 +189,14 @@ export class SavedCohortsPatientListService {
     this._listStorage.set(cohortName, patientLists)
   }
 
+  removePatientList(cohortName: string) {
+    if (this._listStorage.has(cohortName)) {
+      this._listStorage.delete(cohortName)
+    } else {
+      throw ErrorHelper.handleNewError(`Cannot delete patient list for non-existing cohort ${cohortName}`)
+    }
+  }
+
   get authorizedForPatientList(): boolean {
 
     for (const role of this.authenticationService.userRoles) {


### PR DESCRIPTION
Put the time limit unit next to the limit itself in survival settings

Criteria are cleared at expansion of subgroup in survival settings. They are restored when going back to Explore

A bad handling of observable subscription caused the saved cohort error one going back from Analysis whith a freshly created cohort.