### PR TITLE
a spurious error was thrown

### DIFF
--- a/src/app/services/saved-cohorts-patient-list.service.ts
+++ b/src/app/services/saved-cohorts-patient-list.service.ts
@@ -192,8 +192,6 @@ export class SavedCohortsPatientListService {
   removePatientList(cohortName: string) {
     if (this._listStorage.has(cohortName)) {
       this._listStorage.delete(cohortName)
-    } else {
-      throw ErrorHelper.handleNewError(`Cannot delete patient list for non-existing cohort ${cohortName}`)
     }
   }
 


### PR DESCRIPTION
When deleting a cohort that does not have his patient list downloaded, an error was thrown, but it should not.