### PR TITLE
Fix naming of restore tooltip + update the top-left 'selection' box

### DIFF
--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-cohorts/gb-cohorts.component.html
@@ -38,7 +38,7 @@
         <button *ngIf="authorizedForPatientList" pButton class="ui-button-secondary" type="button" pTooltip="Download this cohort for sharing/importing"
           tooltipPosition="top" placeholder="Top" (click)="downloadCohort($event, cohort)" icon="fa fa-download">
         </button>
-        <button pButton class="ui-button-secondary" type="button" pTooltip="Restore" tooltipPosition="top"
+        <button pButton class="ui-button-secondary" type="button" pTooltip="Restore query definition" tooltipPosition="top"
           placeholder="Top" (click)="restoreCohort($event, cohort)" icon="fa fa-arrow-right">
         </button>
         <span>&nbsp;</span>

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.html
@@ -1,3 +1,8 @@
 <div>
   <div>{{globalCount | async}} subjects</div>
+  <ul *ngIf="hasPerSiteCounts && queryResults|async">
+    <li *ngFor="let node of (queryResults|async).nodes; let nodeIdx = index">
+      {{node.name}}: {{(queryResults|async).perSiteCounts[nodeIdx]}} subjects
+    </li>
+  </ul>
 </div>

--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-summary/gb-summary.component.ts
@@ -11,6 +11,7 @@ import { QueryService } from '../../../../services/query.service';
 import { FormatHelper } from '../../../../utilities/format-helper';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import {ExploreQueryResult} from '../../../../models/query-models/explore-query-result';
 
 @Component({
   selector: 'gb-summary',
@@ -27,5 +28,13 @@ export class GbSummaryComponent {
     return this.queryService.queryResults.pipe(map((queryResults) =>
       queryResults ? FormatHelper.formatCountNumber(queryResults.globalCount) : '0'
     ));
+  }
+
+  get hasPerSiteCounts(): boolean {
+    return this.queryService.queryType.hasPerSiteCounts;
+  }
+
+  get queryResults(): Observable<ExploreQueryResult> {
+    return this.queryService.queryResults;
   }
 }

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
@@ -2,7 +2,7 @@
   <p-accordion [multiple]="true">
 
     <div>
-      <p-accordionTab header="Current selection" [selected]="true">
+      <p-accordionTab header="Latest explore query" [selected]="true">
         <gb-summary></gb-summary>
       </p-accordionTab>
     </div>


### PR DESCRIPTION
fix #94
- rename 'restore' to 'restore query definition' in tooltip of cohort selection
- update the top-left selection box:
  - rename title
  - display site count when available