### PR TITLE
logic of construction of milestoned summary table in survival analysis

### DIFF
--- a/src/app/utilities/survival-analysis/summary-table.ts
+++ b/src/app/utilities/survival-analysis/summary-table.ts
@@ -5,28 +5,27 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
-import {SurvivalPoint} from '../../models/survival-analysis/survival-point';
+import { SurvivalPoint } from '../../models/survival-analysis/survival-point';
 
 
 export function summaryTable(points: Array<SurvivalPoint>, milestones: Array<number>): Array<{ atRisk: number, event: number }> {
-  let milestoneIndex = 0
+  let pointIndex = 0
+  const nofPoints = points.length
+
   let cumulAtRisk = points[0].atRisk
   let cumulEvent = 0
   let res = new Array<{ atRisk: number, event: number }>()
-  points.forEach(point => {
-    if (point.timePoint > milestones[milestoneIndex]) {
-      res.push({ atRisk: cumulAtRisk, event: cumulEvent })
-      milestoneIndex++
+
+  milestones.forEach(milestone => {
+
+    while ((nofPoints > pointIndex) && (points[pointIndex].timePoint <= milestone)) {
+      cumulAtRisk = points[pointIndex].atRisk
+      cumulEvent = points[pointIndex].cumulEvents
+      pointIndex++
     }
-    cumulAtRisk = point.atRisk
-    cumulEvent = point.cumulEvents
-  })
 
-
-  // if the observations dont' go as far as the milestones
-  for (let i = milestoneIndex; i < milestones.length; i++) {
     res.push({ atRisk: cumulAtRisk, event: cumulEvent })
 
-  }
+  })
   return res
 }


### PR DESCRIPTION
In SA results, the computation of the values of the milestoned summary table was wrong and put all updated aggregates in front of other values, leading to incoherences between the graph and the this table.

The logic has been refactored and should give now expected results.

 