### PR TITLE
small issues with group names

### DIFF
--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.css
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.css
@@ -104,6 +104,7 @@ p-scrollpanel p.indented{
   border-right: #cccccc 1px solid;
   text-align: center;
   padding:0.5em;
+  white-space: nowrap;
   height:1em;
   font-size: small;
 

--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
@@ -76,6 +76,7 @@
         <tr *ngFor="let summaries of summaryTable; let i = index">
           <td>
             <i class="fa fa-users" aria-hidden="true" [style.color]="colorRange[i]"></i>
+            {{curveNames[i]}}
           </td>
           <td *ngFor="let summary of summaries">{{summary.atRisk}}({{summary.event}})</td>
         </tr>

--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.ts
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.ts
@@ -40,6 +40,7 @@ export class GbSurvivalResultsComponent implements OnInit {
   _inputParameters: SurvivalSettings
   _numericalTables: NumericalTablesType
   _survivalCurve: SurvivalCurve
+  _curveNames: string[]
   _groupComparisons: SelectItem[]
 
   _selectedGroupComparison: {
@@ -116,6 +117,7 @@ export class GbSurvivalResultsComponent implements OnInit {
   display() {
     // -- get the results
     this._survivalCurve = clearResultsToArray(this._results)
+    this._curveNames = this._survivalCurve.curves.map(({ groupId }) => groupId)
 
     // -- remove previous svg
     let previous = select('#survivalSvgContainer svg')
@@ -174,7 +176,6 @@ export class GbSurvivalResultsComponent implements OnInit {
     this._groupTotalEvent = new Array<string>()
     this._groupCoxLogtestTable = new Array<Array<string>>()
     let len = this.survivalCurve.curves.length
-    // let curveName = this.survivalCurve.curves.map(curve => curve.groupId)
     this._groupComparisons = new Array<SelectItem>()
 
     for (let i = 0; i < len; i++) {
@@ -252,34 +253,34 @@ export class GbSurvivalResultsComponent implements OnInit {
       )
 
     }
-    let curveNames = this.survivalCurve.curves.map(({ groupId }) => groupId)
+
     pdfDoc.addOneLineText('Summary')
-    tables = summaryToTable(curveNames, this.groupTotalAtRisk, this.groupTotalEvent, this.groupTotalCensoring)
+    tables = summaryToTable(this.curveNames, this.groupTotalAtRisk, this.groupTotalEvent, this.groupTotalCensoring)
     pdfDoc.addTableFromObjects(tables.headers, tables.data)
 
     pdfDoc.addOneLineText('Summary at time point')
-    tables = milestonedSummaryToTable(curveNames, this.summaryTableMileStones, this._summaryTable)
+    tables = milestonedSummaryToTable(this.curveNames, this.summaryTableMileStones, this._summaryTable)
     pdfDoc.addTableFromObjects(tables.headers, tables.data)
 
-    if (curveNames.length > 1) {
+    if (this.curveNames.length > 1) {
       pdfDoc.addOneLineText('Logrank')
-      console.log(`Debug: curveNames length: ${curveNames.length}; groupLogrank length: ${this.groupLogrankTable}`)
-      let numTables = statTestToTable(curveNames, this.numericalTables.groupLogrankTable)
+      console.log(`Debug: curveNames length: ${this.curveNames.length}; groupLogrank length: ${this.groupLogrankTable}`)
+      let numTables = statTestToTable(this.curveNames, this.numericalTables.groupLogrankTable)
       pdfDoc.addTableFromObjects(numTables.headers, numTables.data)
       pdfDoc.addContentText(numTables.logs)
 
       pdfDoc.addOneLineText('Cox regression coefficient')
-      numTables = statTestToTable(curveNames, this.numericalTables.groupCoxRegTable)
+      numTables = statTestToTable(this.curveNames, this.numericalTables.groupCoxRegTable)
       pdfDoc.addTableFromObjects(numTables.headers, numTables.data)
       pdfDoc.addContentText(numTables.logs)
 
       pdfDoc.addOneLineText('Cox regression wald test')
-      numTables = statTestToTable(curveNames, this.numericalTables.groupCoxWaldTable)
+      numTables = statTestToTable(this.curveNames, this.numericalTables.groupCoxWaldTable)
       pdfDoc.addTableFromObjects(numTables.headers, numTables.data)
       pdfDoc.addContentText(numTables.logs)
 
       pdfDoc.addOneLineText('Logtest')
-      numTables = statTestToTable(curveNames, this.numericalTables.groupCoxLogtestTable)
+      numTables = statTestToTable(this.curveNames, this.numericalTables.groupCoxLogtestTable)
       pdfDoc.addTableFromObjects(numTables.headers, numTables.data)
       pdfDoc.addContentText(numTables.logs)
     }
@@ -363,6 +364,10 @@ export class GbSurvivalResultsComponent implements OnInit {
 
   get survivalCurve(): SurvivalCurve {
     return this._survivalCurve
+  }
+
+  get curveNames(): string[] {
+    return this._curveNames
   }
 
   get groupTables(): SelectItem[] {

--- a/src/app/utilities/rendering/survival-curves-drawing.ts
+++ b/src/app/utilities/rendering/survival-curves-drawing.ts
@@ -204,11 +204,11 @@ export class SurvivalCurvesDrawing {
       )
       )
 
-
+      let title = curve.groupId.length > 8 ? curve.groupId.slice(0, 9) : curve.groupId
       this._svgRef.append('text')
         .attr('x', this._legendxPos + 7)
         .attr('y', this._legendyPos + 5)
-        .text(curve.groupId)
+        .text(title)
       this._legendxPos += this._legendInterval
 
     }).bind(this))


### PR DESCRIPTION
- sometimes, the milestoned summary table in survival analysis contained extra new lines
- sub group names are added to the milestoned summary
- names of sub groups are truncated in SVG, so they don't overlap