### PR TITLE
harmonize font-size of overlay panel

### DIFF
--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
@@ -44,16 +44,19 @@
   </p-accordionTab>
 </p-accordion>
 
-<p-overlayPanel #op [dismissable]="true" [showCloseIcon]="true">
+<p-overlayPanel #op [dismissable]="true" [appendTo]="summary" [showCloseIcon]="true">
 
   Confidence interval:
   <br>
+  <br>
   <p-dropdown [(ngModel)]="selectedIc" [options]="ic" placeholder="confidence interval"></p-dropdown>
-  <p-dropdown [(ngModel)]="selectedAlpha" [options]="alphas" placeholder="1 - &alpha;"
+  <p-dropdown class="input-field-margin" [(ngModel)]="selectedAlpha" [options]="alphas" placeholder="1 - &alpha;"
     [disabled]="(selectedIc) ? false:true"></p-dropdown>
-  <p-button label="Grid" (onClick)="grid = !grid"></p-button>
+  <p-button class="input-field-margin" label="Grid" (onClick)="grid = !grid"></p-button>
+  <br>
   <br>
   Number of ticks (rendering can modify this number to keep nice intervals):
+  <br>
   <br>
   <p-spinner [(ngModel)]="nofTicks" min="1" max="10"></p-spinner>
 

--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
@@ -44,7 +44,7 @@
   </p-accordionTab>
 </p-accordion>
 
-<p-overlayPanel #op [dismissable]="true" [appendTo]="summary" [showCloseIcon]="true">
+<p-overlayPanel #op [dismissable]="true" [showCloseIcon]="true">
 
   Confidence interval:
   <br>

--- a/src/styles/primeng-theme.css
+++ b/src/styles/primeng-theme.css
@@ -1667,6 +1667,10 @@ body .ui-overlaypanel {
   -moz-box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
   box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.3);
 }
+body .ui-overlaypanel-content{
+  font-size: small;
+  margin: 0.5em;
+}
 body .ui-overlaypanel .ui-overlaypanel-close {
   background-color: #ffffff;
   color: #373a3c;


### PR DESCRIPTION
Font-size of overlay panel are set to small.

Unfortunately, appendTo attribute of overlay panel does not seem to have any effect (tested in firefox and chromium), so the parameter panel for survival results is still partially covering the curve graph.