### PR TITLE
Fix font size of the configuration overlay panel in survival results

### DIFF
--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.css
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.css
@@ -129,3 +129,7 @@ canvas{
 #survivalSvgContainer {
   position: relative;
 }
+
+.ci-overlay {
+  font-size: small;
+}

--- a/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
+++ b/src/app/modules/gb-survival-results-module/gb-survival-results.component.html
@@ -44,13 +44,13 @@
   </p-accordionTab>
 </p-accordion>
 
-<p-overlayPanel #op [dismissable]="true" [showCloseIcon]="true">
+<p-overlayPanel class="ci-overlay" #op [dismissable]="true" [showCloseIcon]="true">
 
   Confidence interval:
   <br>
   <p-dropdown [(ngModel)]="selectedIc" [options]="ic" placeholder="confidence interval"></p-dropdown>
   <p-dropdown [(ngModel)]="selectedAlpha" [options]="alphas" placeholder="1 - &alpha;"
-    [disabled]="(selectedIc) ? false:true"></p-dropdown>
+              [disabled]="(!selectedIc)"></p-dropdown>
   <p-button label="Grid" (onClick)="grid = !grid"></p-button>
   <br>
   Number of ticks (rendering can modify this number to keep nice intervals):

--- a/src/app/utilities/rendering/survival-curves-drawing.ts
+++ b/src/app/utilities/rendering/survival-curves-drawing.ts
@@ -118,6 +118,7 @@ export class SurvivalCurvesDrawing {
       .style('z-index', 10)
       .attr('class', 'tooltip')
       .style('background-color', 'white')
+      .style('font-size', 'small')
       .html('Hello')
   }
 


### PR DESCRIPTION
This addresses part of #153.