### PR TITLE
Add warning with unsupported browser and update package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8987,6 +8987,21 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "ngx-device-detector": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/ngx-device-detector/-/ngx-device-detector-2.0.6.tgz",
+      "integrity": "sha512-ltxY19jYl0GzdU/jSOaa3RVrdA9ER7KTZJA/Milp7DyXhhaSymCB8CttnydAmj8gj3AeMi7j3u2bGsycJbDKnA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
+        }
+      }
+    },
     "ngx-toastr": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/ngx-toastr/-/ngx-toastr-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10875,14 +10875,14 @@
       "dev": true
     },
     "quill": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.6.tgz",
-      "integrity": "sha512-K0mvhimWZN6s+9OQ249CH2IEPZ9JmkFuCQeHAOQax3EZ2nDJ3wfGh59mnlQaZV2i7u8eFarx6wAtvQKgShojug==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/quill/-/quill-1.3.7.tgz",
+      "integrity": "sha512-hG/DVzh/TiknWtE6QmWAF/pxoZKYxfe3J/d/+ShUWkDvvkZQVTPeVmUJVu1uE6DDooC4fWTiCLh84ul89oNz5g==",
       "requires": {
         "clone": "^2.1.1",
         "deep-equal": "^1.0.1",
         "eventemitter3": "^2.0.3",
-        "extend": "^3.0.1",
+        "extend": "^3.0.2",
         "parchment": "^1.1.4",
         "quill-delta": "^3.6.2"
       },
@@ -14808,9 +14808,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ=="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -51,14 +51,14 @@
     "primeicons": "^2.0.0",
     "primeng": "^9.1.3",
     "process": "^0.11.10",
-    "quill": "^1.3.6",
+    "quill": "^1.3.7",
     "roboto-fontface": "^0.10.0",
     "rxjs": "^6.6.6",
     "sanitize-filename": "^1.6.3",
     "stream": "0.0.2",
     "tslib": "^1.10.0",
     "vm": "^0.1.0",
-    "xmldom": "^0.1.31",
+    "xmldom": "^0.5.0",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "keycloak-angular": "^7.3.1",
     "keycloak-js": "^10.0.2",
     "mathjs": "^8.0.1",
+    "ngx-device-detector": "^2.0.6",
     "ngx-toastr": "^13.2.0",
     "primeicons": "^2.0.0",
     "primeng": "^9.1.3",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -11,6 +11,7 @@ import {Component, OnInit} from '@angular/core';
 import { AuthenticationService } from './services/authentication.service';
 import {MessageHelper} from './utilities/message-helper';
 import {ToastrService} from 'ngx-toastr';
+import {DeviceDetectorService} from 'ngx-device-detector';
 
 @Component({
   selector: 'gb-app-root',
@@ -21,7 +22,9 @@ export class AppComponent implements OnInit {
 
   private _authenticationCompleted;
 
-  constructor(private toastr: ToastrService, private authenticationService: AuthenticationService) {
+  constructor(private toastr: ToastrService,
+              private authenticationService: AuthenticationService,
+              private deviceService: DeviceDetectorService) {
     this._authenticationCompleted = false;
     // inject toaster service in the MessageHelper
     MessageHelper.toastrService = this.toastr;
@@ -37,7 +40,26 @@ export class AppComponent implements OnInit {
         console.warn('Authenticated failed.');
         MessageHelper.alert('error', 'Authentication failed!');
       }
+
+      this.browserCompatibilityWarning();
     });
+  }
+
+  private browserCompatibilityWarning() {
+    if (!this.deviceService.isDesktop()) {
+      MessageHelper.alert('warn', 'This app has not been tested on mobile and tablet environments, we advise to use a desktop.')
+    }
+
+    const bName = this.deviceService.browser.toLowerCase();
+    const bVersion = parseInt(this.deviceService.browser_version, 10);
+    if (!(bName.includes('chrome') && bVersion >= 80) &&
+      !(bName.includes('firefox') && bVersion >= 78)
+    ) {
+      MessageHelper.alert('warn',
+        `This app has not been tested with your browser (${this.deviceService.browser} ${this.deviceService.browser_version})`
+        + ', we advise to use a recent version of Chrome of Firefox.'
+      );
+    }
   }
 
   get authenticationCompleted(): boolean {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -42,6 +42,7 @@ import {GbResultsModule} from './modules/gb-results-module/gb-results.module';
 import {WorkerModule} from 'angular-web-worker/angular';
 import {DecryptionWorker} from '../decryption.worker';
 import {ToastrModule} from 'ngx-toastr';
+import {DeviceDetectorService} from 'ngx-device-detector';
 
 export function loadServices(config: AppConfig,
                              authService: AuthenticationService,
@@ -103,6 +104,7 @@ export function loadServices(config: AppConfig,
     KeycloakService,
     AuthenticationService,
     ConstraintMappingService,
+    DeviceDetectorService,
     {
       provide: APP_INITIALIZER,
       useFactory: loadServices,


### PR DESCRIPTION
closes #168 

- add warning when using an older version of firefox or chrome, or another browser
- add warning when not on a desktop
- update package.json to take into account warning from `npm audit`

Example of warning:
![Screenshot from 2021-03-17 16-13-04](https://user-images.githubusercontent.com/5486788/111491624-4fb54780-873c-11eb-9602-b375a473057b.png)
