### PR TITLE
survival analysis: fixed button status and for subgroup reset

### DIFF
--- a/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.ts
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-cohort-landing-zone/gb-cohort-landing-zone.component.ts
@@ -154,6 +154,7 @@ export class GbCohortLandingZoneComponent implements OnInit {
 
   reset() {
     this._subGroups = new Array()
+    this.survivalService.subGroups = new Array()
     this._usedNames = new Set()
     this.clearName()
     this.constraintService.clearConstraint()

--- a/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
@@ -5,7 +5,7 @@
       [ngClass]="{'selected': selected==analysisType}" [disabled]="!analysisType.implemented"></button>
     <span pTooltip="You must select a cohort, an analysis, and start and end events (for survival analysis)."
       [tooltipDisabled]="ready" style="float: right;">
-      <button pButton label="Run" [disabled]="!ready" (click)="runAnalysis()"></button>
+      <button pButton label="Run" [disabled]="!ready || cohortService.selectedCohort === undefined" (click)="runAnalysis()"></button>
     </span>
   </div>
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.html
@@ -5,25 +5,25 @@
       [ngClass]="{'selected': selected==analysisType}" [disabled]="!analysisType.implemented"></button>
     <span pTooltip="You must select a cohort, an analysis, and start and end events (for survival analysis)."
       [tooltipDisabled]="ready" style="float: right;">
-      <button pButton label="Run" [disabled]="!ready || cohortService.selectedCohort === undefined" (click)="runAnalysis()"></button>
+      <button pButton label="Run" [disabled]="!ready || selectedCohort === undefined" (click)="runAnalysis()"></button>
     </span>
   </div>
 
   <div *ngIf="selectedSurvival" style="font-size: small; margin-top: 1em;">
     <b>Status:</b>
-    <span *ngIf="!ready && cohortService.selectedCohort === undefined">
+    <span *ngIf="!ready && selectedCohort === undefined">
       You must select a cohort, and start and end events.
     </span>
 
-    <span *ngIf="ready && cohortService.selectedCohort === undefined">
+    <span *ngIf="ready && selectedCohort === undefined">
       You must select a cohort.
     </span>
 
-    <span *ngIf="!ready && cohortService.selectedCohort !== undefined">
+    <span *ngIf="!ready && selectedCohort !== undefined">
       You must select start and end events.
     </span>
 
-    <span *ngIf="ready && cohortService.selectedCohort !== undefined && operationStatus === OperationStatus.done">
+    <span *ngIf="ready && selectedCohort !== undefined && operationStatus === OperationStatus.done">
       Ready.
     </span>
 

--- a/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.ts
+++ b/src/app/modules/gb-analysis-module/panel-components/gb-top/gb-top.component.ts
@@ -20,6 +20,7 @@ import { SurvivalService } from '../../../../services/survival-analysis.service'
 import { SurvivalResultsService } from '../../../../services/survival-results.service';
 import { AnalysisService } from '../../../../services/analysis.service';
 import { HttpErrorResponse } from '@angular/common/http';
+import { Cohort } from 'src/app/models/cohort-models/cohort';
 
 @Component({
   selector: 'gb-top',
@@ -159,6 +160,10 @@ export class GbTopComponent {
   get ready(): boolean {
     return this._ready &&
       this.selected !== undefined
+  }
+
+  get selectedCohort(): Cohort {
+    return this.cohortService.selectedCohort
   }
 }
 


### PR DESCRIPTION
Fixed two small issues in survival settings

- Run button issue: when events were selected, but not the cohort, Run button was already activated
- Reset button emptied the sub groups array for this component, but not this of survival settings service that ultimately sends them for API calls.
