### PR TITLE
Explore: fix the inner size of dropdown label

### DIFF
--- a/src/styles/primeng-theme.css
+++ b/src/styles/primeng-theme.css
@@ -286,6 +286,7 @@ body .ui-dropdown:not(.ui-state-disabled).ui-state-focus {
   border-color: #cccccc;
 }
 body .ui-dropdown .ui-dropdown-label {
+  min-width: 12em;
   padding-right: 2em;
 }
 body .ui-dropdown .ui-dropdown-label .ui-placeholder {


### PR DESCRIPTION
The size of the dropdown select menu seems to be fixed, but not the inner box for label.
The label's background is white and this behaviour was visible in concept-constraint as the constraint boxes have a grey background.