### PR TITLE
fix issues #202 and #204

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,7 +53,9 @@ export class AppComponent implements OnInit {
     const bName = this.deviceService.browser.toLowerCase();
     const bVersion = parseInt(this.deviceService.browser_version, 10);
     if (!(bName.includes('chrome') && bVersion >= 80) &&
-      !(bName.includes('firefox') && bVersion >= 78)
+      !(bName.includes('firefox') && bVersion >= 78) &&
+      !(bName.includes('safari') && bVersion >= 13) &&
+      !(bName.includes('opera') && bVersion >= 67)
     ) {
       MessageHelper.alert('warn',
         `This app has not been tested with your browser (${this.deviceService.browser} ${this.deviceService.browser_version})`

--- a/src/app/services/constraint-mapping.service.ts
+++ b/src/app/services/constraint-mapping.service.ts
@@ -14,7 +14,7 @@ import {ApiI2b2Timing} from '../models/api-request-models/medco-node/api-i2b2-ti
 import {TextOperator} from '../models/constraint-models/text-operator';
 import {NumericalOperator} from '../models/constraint-models/numerical-operator';
 import {ApiI2B2Modifier} from '../models/api-request-models/medco-node/api-i2b2-modifier';
-
+import {Concept} from '../models/constraint-models/concept';
 
 @Injectable()
 export class ConstraintMappingService {
@@ -110,8 +110,11 @@ export class ConstraintMappingService {
   }
 
   private generateI2b2ItemFromConcept(constraint: ConceptConstraint): ApiI2b2Item {
-    let item = new ApiI2b2Item();
+    if (!(constraint.concept instanceof Concept)) {
+      throw ErrorHelper.handleNewUserInputError(`Invalid query term "${constraint.concept}"`);
+    }
 
+    let item = new ApiI2b2Item();
     if (constraint.concept.encryptionDescriptor.encrypted) {
       // todo: children IDs implementation
       item.encrypted = true;


### PR DESCRIPTION
- closes #202: extend to opera and safari the compatibility warning
- closes #204: check that a concept is valid during mapping to throw a clean error when not