### PR TITLE
Button/tree node style, allows to click on the whole treenode-content

### DIFF
--- a/src/app/modules/gb-side-panel-module/accordion-components/gb-tree-nodes/gb-tree-nodes.component.ts
+++ b/src/app/modules/gb-side-panel-module/accordion-components/gb-tree-nodes/gb-tree-nodes.component.ts
@@ -112,6 +112,11 @@ export class GbTreeNodesComponent implements AfterViewInit, AfterViewChecked {
       let metadata = dataObject.metadata;
       let treeNodeElm = elm.querySelector('li.ui-treenode');
       let treeNodeElmIcon = elm.querySelector('li.ui-treenode .ui-treenode-icon');
+      let treeNodeToggler = elm.querySelector('li.ui-treenode .ui-tree-toggler');
+      let treeNodeContent = elm.querySelector('li.ui-treenode .ui-treenode-content');
+      let onClickTreeNodeContent = (function() {
+        treeNodeToggler.click();
+      }).bind(this);
       let handleDragstart = (function (event) {
         event.stopPropagation();
         dataObject.dropMode = DropMode.TreeNode;
@@ -135,6 +140,8 @@ export class GbTreeNodesComponent implements AfterViewInit, AfterViewChecked {
         treeNodeElmIcon.addEventListener('mouseleave', hideInfo);
       }
       */
+
+      treeNodeContent.addEventListener('click', onClickTreeNodeContent, true);
 
       // if the data object type is known, it is considered queryable
       if (dataObject.nodeType !== TreeNodeType.UNKNOWN) {

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -41,6 +41,10 @@ textarea {
   font-family: 'Roboto', sans-serif;
 }
 
+button {
+  cursor: pointer;
+}
+
 .loading-message {
   background-color: var(--gb-loading-bg-color);
   color: white;
@@ -421,6 +425,17 @@ gb-tree-nodes .gb-highlight-treenode {
  * should be left empty
  */
 gb-tree-nodes .gb-is-not-leaf {
+}
+
+gb-tree-nodes .ui-treenode-content {
+  cursor: pointer;
+  padding: 4px 0px;
+  border-radius: 2px;
+  transition: 0.15s ease-in-out background-color;
+}
+
+gb-tree-nodes .ui-treenode-content:hover {
+  background-color: rgba(51, 156, 144, 0.2);
 }
 
 /*


### PR DESCRIPTION
1. Button cursor style, using pointer by default : 
![image](https://user-images.githubusercontent.com/10889224/120766083-2a093480-c51a-11eb-80c8-9dcb17a81505.png)
->
![image](https://user-images.githubusercontent.com/10889224/120766105-2f667f00-c51a-11eb-849c-33116c7fde53.png)


2. Treenode-content, to be able to click on the whole line, add hover effect and added a little padding ease-of-reading and clicking :
![image](https://user-images.githubusercontent.com/10889224/120766332-6b99df80-c51a-11eb-8d78-470ec025c90e.png)
->
![image](https://user-images.githubusercontent.com/10889224/120766511-984df700-c51a-11eb-9907-2faa341da16a.png)


Just some suggested improvements for the UI of glowing-bear