### PR TITLE
Subject counts next to ontology concepts and modfiers

### DIFF
--- a/src/app/models/tree-models/tree-node.ts
+++ b/src/app/models/tree-models/tree-node.ts
@@ -49,8 +49,8 @@ export class TreeNode implements PrimeNgTreeNode {
   parent: TreeNode;
   partialSelected: boolean;
 
-  //An indicator saying whether or not the process of loading the children of this node started.
-  childrenLoadingStarted: boolean = false;
+  // An indicator saying whether or not the process of loading the children of this node started.
+  childrenLoadingStarted = false;
 
   clone(): TreeNode {
     let copy: TreeNode = new TreeNode();
@@ -124,19 +124,19 @@ export class TreeNode implements PrimeNgTreeNode {
       || (this.nodeType === TreeNodeType.MODIFIER_CONTAINER)
       || (this.nodeType === TreeNodeType.MODIFIER_FOLDER))
   }
-  
+
   /*
    * This method refresh this parent's children subject counts with the subject count of @param updatedChildren
    * @param {TreeNode[]} updateChildren contains the children with updated subjects counts
    */
   refreshChildrenSubjectsCounts(updatedChildren: TreeNode[]) {
     if (!this.hasChildren()) {
-      console.error("could not update children counts of this node, it does not have any children")
+      console.error('could not update children counts of this node, it does not have any children')
       return;
     }
-    
+
     updatedChildren.forEach(updatedChild => {
-      const matchingChild = this.children.find(child => child.path == updatedChild.path)
+      const matchingChild = this.children.find(child => child.path === updatedChild.path)
       matchingChild.subjectCount = updatedChild.subjectCount;
     })
   }

--- a/src/app/models/tree-models/tree-node.ts
+++ b/src/app/models/tree-models/tree-node.ts
@@ -28,6 +28,8 @@ export class TreeNode implements PrimeNgTreeNode {
   depth: number;
   // number of subject (possibly undefined) associated with this node
   subjectCount: number;
+  // encrypted number of subject (possibly undefined) associated with this node. Usually computed by aggregation on the server side.
+  subjectCountEncrypted: string;
 
 
   // flag to signal if the children were requested to the backend
@@ -46,6 +48,9 @@ export class TreeNode implements PrimeNgTreeNode {
   styleClass: string;
   parent: TreeNode;
   partialSelected: boolean;
+
+  //An indicator saying whether or not the process of loading the children of this node started.
+  childrenLoadingStarted: boolean = false;
 
   clone(): TreeNode {
     let copy: TreeNode = new TreeNode();
@@ -66,6 +71,7 @@ export class TreeNode implements PrimeNgTreeNode {
     }
     copy.depth = this.depth;
     copy.subjectCount = this.subjectCount;
+    copy.subjectCountEncrypted = this.subjectCountEncrypted;
     copy.childrenAttached = this.childrenAttached;
     if (this.encryptionDescriptor) {
       copy.encryptionDescriptor = new MedcoEncryptionDescriptor()
@@ -83,6 +89,8 @@ export class TreeNode implements PrimeNgTreeNode {
     copy.expanded = this.expanded;
     copy.styleClass = this.styleClass;
     copy.partialSelected = this.partialSelected;
+    copy.childrenLoadingStarted = this.childrenLoadingStarted;
+
     return copy
   }
 
@@ -115,6 +123,22 @@ export class TreeNode implements PrimeNgTreeNode {
     return ((this.nodeType === TreeNodeType.MODIFIER)
       || (this.nodeType === TreeNodeType.MODIFIER_CONTAINER)
       || (this.nodeType === TreeNodeType.MODIFIER_FOLDER))
+  }
+  
+  /*
+   * This method refresh this parent's children subject counts with the subject count of @param updatedChildren
+   * @param {TreeNode[]} updateChildren contains the children with updated subjects counts
+   */
+  refreshChildrenSubjectsCounts(updatedChildren: TreeNode[]) {
+    if (!this.hasChildren()) {
+      console.error("could not update children counts of this node, it does not have any children")
+      return;
+    }
+    
+    updatedChildren.forEach(updatedChild => {
+      const matchingChild = this.children.find(child => child.path == updatedChild.path)
+      matchingChild.subjectCount = updatedChild.subjectCount;
+    })
   }
 
   /**

--- a/src/app/services/api/medco-node/explore-search.service.ts
+++ b/src/app/services/api/medco-node/explore-search.service.ts
@@ -9,15 +9,15 @@
  */
 
 import { ValueType } from '../../../models/constraint-models/value-type';
-import {ApiValueMetadata, DataType} from '../../../models/api-response-models/medco-node/api-value-metadata';
-import {MessageHelper} from '../../../utilities/message-helper';
-import {Injectable, Injector} from '@angular/core';
-import {AppConfig} from '../../../config/app.config';
-import {HttpClient} from '@angular/common/http';
-import {Observable} from 'rxjs';
-import {map} from 'rxjs/operators'
-import {TreeNode} from '../../../models/tree-models/tree-node';
-import {TreeNodeType} from '../../../models/tree-models/tree-node-type';
+import { ApiValueMetadata, DataType } from '../../../models/api-response-models/medco-node/api-value-metadata';
+import { MessageHelper } from '../../../utilities/message-helper';
+import { Injectable, Injector } from '@angular/core';
+import { AppConfig } from '../../../config/app.config';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators'
+import { TreeNode } from '../../../models/tree-models/tree-node';
+import { TreeNodeType } from '../../../models/tree-models/tree-node-type';
 import { MedcoNetworkService } from '../medco-network.service';
 import { ApiEndpointService } from '../../api-endpoint.service';
 
@@ -43,15 +43,16 @@ export class ExploreSearchService {
    * Perform search concept in ontology.
    *
    * @param {string} root - the path to the specific tree node, must include the first slash
-   * @param {string} publicKey the public key that will be used in order by the medco to encrypt the subject counts of the concepts and modifiers.
+   * @param {string} publicKey the public key that will be used in order by
+   *   the medco to encrypt the subject counts of the concepts and modifiers.
    * @param {string} queryID an ID used to identify the query by the backend in order to perform aggregation of subjectCounts.
    * @returns {Observable<Object>}
    */
   exploreSearchConcept(operation: string, root: string, apiURL?: string, publicKey?: string, queryID?: string): Observable<TreeNode[]> {
 
-    const queryParams: object = { type: 'children', path: root, operation: operation}
+    const queryParams: object = { type: 'children', path: root, operation: operation }
     if (queryID && publicKey) {
-      queryParams["subjectCountQueryInfo"] = {userPublicKey: publicKey, queryID: queryID}
+      queryParams['subjectCountQueryInfo'] = { userPublicKey: publicKey, queryID: queryID }
     }
 
     return this.apiEndpointService.postCall(
@@ -110,7 +111,7 @@ export class ExploreSearchService {
 
     const jsonSubjectCount = treeNodeObj['subjectCount'];
     if (jsonSubjectCount) {
-      treeNode.subjectCount = parseInt(jsonSubjectCount);
+      treeNode.subjectCount = parseInt(jsonSubjectCount, 10);
     }
     treeNode.subjectCountEncrypted = treeNodeObj['subjectCountEncrypted'];
 
@@ -126,7 +127,7 @@ export class ExploreSearchService {
 
     const queryParams: object = { path: root, appliedPath: appliedPath, appliedConcept: appliedConcept, operation: operation }
     if (queryID && publicKey) {
-      queryParams["subjectCountQueryInfo"] = {userPublicKey: publicKey, queryID: queryID}
+      queryParams['subjectCountQueryInfo'] = { userPublicKey: publicKey, queryID: queryID }
     }
 
     return this.apiEndpointService.postCall(
@@ -232,7 +233,8 @@ export class ExploreSearchService {
    *
    * @returns {Observable<Object>}
    */
-  exploreSearchModifierChildren(root: string, appliedPath: string, appliedConcept: string, medcoNodeUrl?: string, publicKey?: string, queryID?: string): Observable<TreeNode[]> {
+  exploreSearchModifierChildren(root: string, appliedPath: string, appliedConcept: string,
+    medcoNodeUrl?: string, publicKey?: string, queryID?: string): Observable<TreeNode[]> {
     return this.exploreSearchModifier('children', root, appliedPath, appliedConcept, medcoNodeUrl, publicKey, queryID);
   }
 
@@ -243,7 +245,8 @@ export class ExploreSearchService {
    *
    * @returns {Observable<Object>}
    */
-  exploreSearchModifierInfo(root: string, appliedPath: string, appliedConcept: string, medcoNodeUrl?: string, publicKey?: string, queryID?: string): Observable<TreeNode[]> {
+  exploreSearchModifierInfo(root: string, appliedPath: string, appliedConcept: string,
+      medcoNodeUrl?: string, publicKey?: string, queryID?: string): Observable<TreeNode[]> {
     return this.exploreSearchModifier('info', root, appliedPath, appliedConcept, medcoNodeUrl, publicKey, queryID)
   }
 }


### PR DESCRIPTION
![totalnumPR](https://user-images.githubusercontent.com/8803839/123238614-e84b2880-d4de-11eb-9ae9-626639fd5476.png)

This feature brings the display of subject counts per concept present in the ontology.

User benefit: a privileged user can see  which concepts have no observations and which are densely populated and optimize inclusion/exclusion criteria.

The related back-end PR is [here](https://github.com/ldsec/medco/pull/99).