### PR TITLE
Allow saving cohort for all users.

### DIFF
--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -108,7 +108,18 @@ export class GbExploreComponent implements AfterViewChecked {
       this.savedCohortsPatientListService.insertPatientList(this.cohortName, this._lastPatientList[0], this._lastPatientList[1])
       this.savedCohortsPatientListService.statusStorage.set(this.cohortName, OperationStatus.done)
     } else {
-      MessageHelper.alert('error', 'There is no patient list cached from previous Explore Query. You may have to download the list again.')
+      switch (this.queryService.queryType) {
+        case ExploreQueryType.COUNT_PER_SITE:
+        case ExploreQueryType.COUNT_PER_SITE_OBFUSCATED:
+        case ExploreQueryType.COUNT_PER_SITE_SHUFFLED:
+        case ExploreQueryType.COUNT_PER_SITE_SHUFFLED_OBFUSCATED:
+        case ExploreQueryType.PATIENT_LIST:
+          MessageHelper.alert('error', 'There is no patient list cached from previous Explore Query. You may have to download the list again.')
+          break;
+        default:
+          //In this case no patient list is available in the return type of the explore query anyway.
+          break;
+      }
     }
     this.cohortName = ''
   }

--- a/src/app/modules/gb-explore-module/gb-explore.component.ts
+++ b/src/app/modules/gb-explore-module/gb-explore.component.ts
@@ -117,7 +117,7 @@ export class GbExploreComponent implements AfterViewChecked {
           MessageHelper.alert('error', 'There is no patient list cached from previous Explore Query. You may have to download the list again.')
           break;
         default:
-          //In this case no patient list is available in the return type of the explore query anyway.
+          // In this case no patient list is available in the return type of the explore query anyway.
           break;
       }
     }

--- a/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
+++ b/src/app/modules/gb-side-panel-module/gb-side-panel.component.html
@@ -35,7 +35,7 @@
     </div>
 
     <div>
-      <p-accordionTab header="Saved Cohorts" *ngIf="savedCohortsPatientListService.authorizedForPatientList" [selected]="true">
+      <p-accordionTab header="Saved Cohorts" [selected]="true">
         <gb-cohorts></gb-cohorts>
       </p-accordionTab>
     </div>

--- a/src/app/services/query.service.ts
+++ b/src/app/services/query.service.ts
@@ -97,6 +97,7 @@ export class QueryService {
             let parsedResults = new ExploreQueryResult();
             parsedResults.nodes = encResults.map(res => res[0]);
             parsedResults.globalCount = decrypted[0];
+            parsedResults.resultInstanceID = encResults.map(result => result[1].queryID)
             return parsedResults;
           })
         );


### PR DESCRIPTION
The idea is simple. Allowing all users to save cohorts. 

Goes hand in hand with [this PR](https://github.com/ldsec/medco/pull/131).

Some constraints disallowed it in the current state of the dev branch. If the user has no rights to see the patient list this was impossible for the user to save a cohort from an explore query.

The submitted solution allows users without the right to visualize and download the patient list to save the cohort. When an explore query returns, the query id of the explore query saved in the medco connector database is returned by the backend. This query id is then usable as a mean to identify the cohort to save when the user presses the save cohort button. 